### PR TITLE
Add custom voice ID and model selection for ElevenLabs TTS

### DIFF
--- a/RST.csproj
+++ b/RST.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
-    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
+    <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
+    <SupportedOSPlatformVersion>10.0.26100.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>

--- a/src/ConfigManager.cs
+++ b/src/ConfigManager.cs
@@ -121,6 +121,7 @@ namespace RSTGameTranslation
         public const string TTS_SERVICE = "tts_service";
         public const string ELEVENLABS_API_KEY = "elevenlabs_api_key";
         public const string ELEVENLABS_VOICE = "elevenlabs_voice";
+        public const string ELEVENLABS_MODEL = "elevenlabs_model";
         public const string GOOGLE_TTS_API_KEY = "google_tts_api_key";
         public const string GOOGLE_TTS_VOICE = "google_tts_voice";
         public const string WINDOWS_TTS_VOICE = "windows_tts_voice";
@@ -486,6 +487,7 @@ namespace RSTGameTranslation
             _configValues[TARGET_LANGUAGE] = "vi";
             _configValues[ELEVENLABS_API_KEY] = "<your API key here>";
             _configValues[ELEVENLABS_VOICE] = "21m00Tcm4TlvDq8ikWAM";
+            _configValues[ELEVENLABS_MODEL] = "eleven_flash_v2_5";
             _configValues[TTS_SERVICE] = "Windows TTS";
             _configValues[GOOGLE_TTS_API_KEY] = "<your API key here>";
             _configValues[GOOGLE_TTS_VOICE] = "ja-JP-Neural2-B";
@@ -2218,6 +2220,22 @@ namespace RSTGameTranslation
                 _configValues[ELEVENLABS_VOICE] = voiceId;
                 SaveConfig();
                 Console.WriteLine($"ElevenLabs voice set to: {voiceId}");
+            }
+        }
+
+        // Get/Set ElevenLabs model
+        public string GetElevenLabsModel()
+        {
+            return GetValue(ELEVENLABS_MODEL, "eleven_flash_v2_5"); // Default to Flash v2.5
+        }
+
+        public void SetElevenLabsModel(string modelId)
+        {
+            if (!string.IsNullOrWhiteSpace(modelId))
+            {
+                _configValues[ELEVENLABS_MODEL] = modelId;
+                SaveConfig();
+                Console.WriteLine($"ElevenLabs model set to: {modelId}");
             }
         }
 

--- a/src/ElevenLabsService.cs
+++ b/src/ElevenLabsService.cs
@@ -99,18 +99,21 @@ namespace RSTGameTranslation
                 _httpClient.DefaultRequestHeaders.Remove("xi-api-key");
                 _httpClient.DefaultRequestHeaders.Add("xi-api-key", apiKey);
                 
-                // Ensure we have a valid voice ID
-                if (string.IsNullOrWhiteSpace(voice) || !DefaultVoices.ContainsValue(voice))
+                // Ensure we have a valid voice ID (allow custom voice IDs)
+                if (string.IsNullOrWhiteSpace(voice))
                 {
-                    // Use Rachel as default
+                    // Use Rachel as default only if no voice is configured
                     voice = DefaultVoices["Rachel"];
                 }
                 
+                // Get model from config (defaults to eleven_flash_v2_5)
+                string model = ConfigManager.Instance.GetElevenLabsModel();
+
                 // Create request payload
                 var requestData = new
                 {
                     text = text,
-                    model_id = "eleven_flash_v2_5",
+                    model_id = model,
                     voice_settings = new
                     {
                         stability = 0.5,

--- a/src/SettingsWindow.xaml
+++ b/src/SettingsWindow.xaml
@@ -1069,13 +1069,16 @@
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/> <!-- Row 0: Enable TTS -->
+                                    <RowDefinition Height="Auto"/> <!-- Row 1: TTS Service -->
+                                    <RowDefinition Height="Auto"/> <!-- Row 2: API Key -->
+                                    <RowDefinition Height="Auto"/> <!-- Row 3: Voice dropdown -->
+                                    <RowDefinition Height="Auto"/> <!-- Row 4: Custom Voice ID -->
+                                    <RowDefinition Height="Auto"/> <!-- Row 5: Model -->
+                                    <RowDefinition Height="Auto"/> <!-- Row 6: spacer -->
+                                    <RowDefinition Height="Auto"/> <!-- Row 7: Exclude Character Name -->
                                 </Grid.RowDefinitions>
-                                
+
                                 <!-- TTS Enabled -->
                                 <TextBlock Text="{Binding Source={x:Static local:LocalizationManager.Instance}, Path=Strings[Lbl_EnableTTS]}" Grid.Row="0" Grid.Column="0" 
                                           VerticalAlignment="Center" Margin="0,0,10,0"/>
@@ -1084,12 +1087,12 @@
                                          Checked="TtsEnabledCheckBox_CheckedChanged" 
                                          Unchecked="TtsEnabledCheckBox_CheckedChanged"/>
                                 
-                                <TextBlock Text="{Binding Source={x:Static local:LocalizationManager.Instance}, Path=Strings[Lbl_ExcludeCharName]}" Grid.Row="4" Grid.Column="0" 
+                                <TextBlock Text="{Binding Source={x:Static local:LocalizationManager.Instance}, Path=Strings[Lbl_ExcludeCharName]}" Grid.Row="7" Grid.Column="0"
                                           ToolTip="{Binding Source={x:Static local:LocalizationManager.Instance}, Path=Strings[Tip_ExcludeCharName]}"
                                           VerticalAlignment="Center" Margin="0,0,10,0"/>
-                                <CheckBox x:Name="excludeCharacterNameCheckBox" Grid.Row="4" Grid.Column="1" 
-                                         Margin="0,5" 
-                                         Checked="ExcludeCharacterNameCheckBox_CheckedChanged" 
+                                <CheckBox x:Name="excludeCharacterNameCheckBox" Grid.Row="7" Grid.Column="1"
+                                         Margin="0,5"
+                                         Checked="ExcludeCharacterNameCheckBox_CheckedChanged"
                                          Unchecked="ExcludeCharacterNameCheckBox_CheckedChanged"/>
                                 
                                 <!-- TTS Service -->
@@ -1123,7 +1126,7 @@
                                 <!-- ElevenLabs Voice - Only visible when ElevenLabs is selected -->
                                 <TextBlock x:Name="elevenLabsVoiceLabel" Text="{Binding Source={x:Static local:LocalizationManager.Instance}, Path=Strings[Lbl_ElevenLabsVoice]}" Grid.Row="3" Grid.Column="0" 
                                           VerticalAlignment="Center" Margin="0,5,10,0"/>
-                                <ComboBox x:Name="elevenLabsVoiceComboBox" Grid.Row="3" Grid.Column="1" 
+                                <ComboBox x:Name="elevenLabsVoiceComboBox" Grid.Row="3" Grid.Column="1"
                                          Margin="0,5" SelectionChanged="ElevenLabsVoiceComboBox_SelectionChanged">
                                     <ComboBoxItem Content="Rachel" Tag="21m00Tcm4TlvDq8ikWAM"/>
                                     <ComboBoxItem Content="Domi" Tag="AZnzlk1XvdvUeBnXmlld"/>
@@ -1136,6 +1139,24 @@
                                     <ComboBoxItem Content="Sam" Tag="yoZ06aMxZJJ28mfd3POQ"/>
                                     <ComboBoxItem Content="MC Anh Đức" Tag="XBDAUT8ybuJTTCoOLSUj"/>
                                     <ComboBoxItem Content="Mc Hà My - Vietnames - calm and kind" Tag="RmcV9cAq1TByxNSgbii7"/>
+                                    <ComboBoxItem Content="Custom Voice ID..." Tag="custom"/>
+                                </ComboBox>
+
+                                <!-- Custom Voice ID - Only visible when Custom is selected -->
+                                <TextBlock x:Name="elevenLabsCustomVoiceLabel" Text="Custom Voice ID:" Grid.Row="4" Grid.Column="0"
+                                          VerticalAlignment="Center" Margin="0,5,10,0" Visibility="Collapsed"/>
+                                <TextBox x:Name="elevenLabsCustomVoiceTextBox" Grid.Row="4" Grid.Column="1"
+                                         Margin="0,5" Visibility="Collapsed" TextChanged="ElevenLabsCustomVoiceTextBox_TextChanged"/>
+
+                                <!-- ElevenLabs Model - Only visible when ElevenLabs is selected -->
+                                <TextBlock x:Name="elevenLabsModelLabel" Text="Model:" Grid.Row="5" Grid.Column="0"
+                                          VerticalAlignment="Center" Margin="0,5,10,0" Visibility="Collapsed"/>
+                                <ComboBox x:Name="elevenLabsModelComboBox" Grid.Row="5" Grid.Column="1"
+                                         Margin="0,5" Visibility="Collapsed" SelectionChanged="ElevenLabsModelComboBox_SelectionChanged">
+                                    <ComboBoxItem Content="Flash v2.5 (Fastest, 50% off)" Tag="eleven_flash_v2_5"/>
+                                    <ComboBoxItem Content="Turbo v2.5 (Balanced, 50% off)" Tag="eleven_turbo_v2_5"/>
+                                    <ComboBoxItem Content="Multilingual v2 (High quality)" Tag="eleven_multilingual_v2"/>
+                                    <ComboBoxItem Content="Eleven v3 (Best, alpha)" Tag="eleven_v3"/>
                                 </ComboBox>
 
                                 <!-- Windows TTS Voice - Only visible when Windows TTS is selected -->


### PR DESCRIPTION
Notes: 
- Updated net9.0-windows10.0.19041.0 to net9.0-windows10.0.26100.0 (likely not required but was the version I had installed)

Features:
- Add "Custom Voice ID..." option to ElevenLabs voice dropdown
- Add text input for entering custom voice IDs (shown when Custom selected)
- Add Model dropdown with Flash v2.5, Turbo v2.5, Multilingual v2, Eleven v3
- Add elevenlabs_model config option with eleven_flash_v2_5 as default

Bug fixes:
- Fix validation that rejected custom voice IDs not in preset list
- Previously only hardcoded default voices were accepted, now any valid ElevenLabs voice ID works

This allows users to use their own cloned/custom ElevenLabs voices and choose between different TTS models with varying quality/speed/cost tradeoffs.